### PR TITLE
Refactor spend over/under target calculations and UI display

### DIFF
--- a/app/BudgetDashboard.tsx
+++ b/app/BudgetDashboard.tsx
@@ -9,6 +9,8 @@ import {
 } from "../lib/transactionsLoader"
 import { useBudgetDashboard } from "../state/hooks"
 import { KpiCards } from "../components/KpiCards"
+import { MonthlyStatsCards } from "../components/MonthlyStatsCards"
+import { StatsProgressMeters } from "../components/StatsProgressMeters"
 import { ChartBarBudget } from "../components/ChartBarBudget"
 import { ChartDonutCat } from "../components/ChartDonutCat"
 import { ChartLineDaily } from "../components/ChartLineDaily"
@@ -103,6 +105,47 @@ export default function BudgetDashboard() {
     )
   }
 
+  // --- Monthly Metrics Calculation ---
+  // Monthly Cumulative Spending
+  const monthlyCumulativeSpending = totalSpentThisMonth
+
+  // Rent & Utilities
+  const rentAndUtilities = spendByCategory["Rent & Utilities"] || 0
+  // The Rest
+  const theRest = monthlyCumulativeSpending - rentAndUtilities
+
+  // Tentative Monthly Budget (hardcoded)
+  const tentativeMonthlyBudget = 50000
+
+  // Days in month
+  const today = new Date()
+  const daysInMonth = new Date(selectedMonth.getFullYear(), selectedMonth.getMonth() + 1, 0).getDate()
+  const isCurrentMonth = today.getMonth() === selectedMonth.getMonth() && today.getFullYear() === selectedMonth.getFullYear()
+  const currentDay = isCurrentMonth ? today.getDate() : daysInMonth
+  const daysElapsed = currentDay
+  const daysLeft = daysInMonth - currentDay
+
+  // Fixed costs for the month
+  const fixedCosts = spendByCategory["Rent & Utilities"] || 0 // or sum fixed expenses if tracked separately
+
+  // Avg Spend per Day (user formula)
+  const avgSpendPerDay = daysInMonth > 0 && daysElapsed > 0
+    ? (fixedCosts / daysInMonth) + ((monthlyCumulativeSpending - fixedCosts) / daysElapsed)
+    : 0
+
+  // Target Spend per Day (user formula)
+  const targetSpendPerDay = tentativeMonthlyBudget / daysInMonth
+
+  // % Over or Under Target (user formula)
+  const percentOverUnderTarget = targetSpendPerDay > 0
+    ? ((targetSpendPerDay - avgSpendPerDay) / targetSpendPerDay) * 100
+    : 0
+
+  // Spend/Day Allowed to Reach Target by EoM (user formula)
+  const spendPerDayAllowed = daysLeft > 0
+    ? (tentativeMonthlyBudget - monthlyCumulativeSpending) / daysLeft
+    : 0
+
   return (
     <div className="min-h-screen bg-[#F9FAFC] p-4 md:p-6">
       <header className="flex flex-col md:flex-row justify-between items-start md:items-center mb-6">
@@ -148,6 +191,24 @@ export default function BudgetDashboard() {
           </ToggleGroup>
         </div>
       </header>
+
+      {/* Monthly Stats Section */}
+      <MonthlyStatsCards
+        monthlyCumulativeSpending={monthlyCumulativeSpending}
+        rentAndUtilities={rentAndUtilities}
+        theRest={theRest}
+        tentativeMonthlyBudget={tentativeMonthlyBudget}
+        avgSpendPerDay={avgSpendPerDay}
+        targetSpendPerDay={targetSpendPerDay}
+        percentOverUnderTarget={percentOverUnderTarget}
+        spendPerDayAllowed={isFinite(spendPerDayAllowed) && spendPerDayAllowed > 0 ? spendPerDayAllowed : 0}
+      />
+      <StatsProgressMeters
+        monthlyCumulativeSpending={monthlyCumulativeSpending}
+        tentativeMonthlyBudget={tentativeMonthlyBudget}
+        avgSpendPerDay={avgSpendPerDay}
+        targetSpendPerDay={targetSpendPerDay}
+      />
 
       {/* KPI Cards */}
       <KpiCards

--- a/components/MonthlyStatsCards.tsx
+++ b/components/MonthlyStatsCards.tsx
@@ -1,0 +1,106 @@
+import React from "react"
+
+// Simple tooltip component
+const Tooltip: React.FC<{ text: string }> = ({ text }) => (
+  <span className="relative group ml-1 cursor-pointer">
+    <span className="text-gray-400">&#9432;</span>
+    <span className="absolute left-1/2 z-10 hidden group-hover:block bg-black text-white text-xs rounded px-2 py-1 -translate-x-1/2 mt-2 whitespace-pre max-w-xs w-max">
+      {text}
+    </span>
+  </span>
+)
+
+interface MonthlyStatsCardsProps {
+  monthlyCumulativeSpending: number
+  rentAndUtilities: number
+  theRest: number
+  tentativeMonthlyBudget: number
+  avgSpendPerDay: number
+  targetSpendPerDay: number
+  percentOverUnderTarget: number
+  spendPerDayAllowed: number
+}
+
+export const MonthlyStatsCards: React.FC<MonthlyStatsCardsProps> = ({
+  monthlyCumulativeSpending,
+  rentAndUtilities,
+  theRest,
+  tentativeMonthlyBudget,
+  avgSpendPerDay,
+  targetSpendPerDay,
+  percentOverUnderTarget,
+  spendPerDayAllowed,
+}) => {
+  // Helper for formatting INR
+  const formatCurrency = (amount: number) =>
+    amount.toLocaleString("en-IN", { style: "currency", currency: "INR", maximumFractionDigits: 2 })
+
+  // Show as percent: ((avgSpendPerDay - targetSpendPerDay) / targetSpendPerDay) * 100
+  const overUnderPercent = targetSpendPerDay === 0 ? 0 : ((avgSpendPerDay - targetSpendPerDay) / targetSpendPerDay) * 100;
+  const overUnderColor = overUnderPercent > 1 ? "text-red-600" : "text-green-600";
+  const overUnderLabel = `${overUnderPercent > 0 ? '+' : ''}${overUnderPercent.toFixed(2)}%`;
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+      {/* First Row */}
+      <div className="bg-white rounded-lg shadow p-4 flex flex-col items-center">
+        <span className="text-xs text-gray-500 mb-1">
+          Monthly Cumulative Spending
+          <Tooltip text={"Sum of all spending so far this month."} />
+        </span>
+        <span className="text-xl font-semibold">{formatCurrency(monthlyCumulativeSpending)}</span>
+      </div>
+      <div className="bg-white rounded-lg shadow p-4 flex flex-col items-center">
+        <span className="text-xs text-gray-500 mb-1">
+          Rent & Utilities
+          <Tooltip text={"Total of all 'Rent & Utilities' transactions for this month."} />
+        </span>
+        <span className="text-xl font-semibold">{formatCurrency(rentAndUtilities)}</span>
+      </div>
+      <div className="bg-white rounded-lg shadow p-4 flex flex-col items-center">
+        <span className="text-xs text-gray-500 mb-1">
+          The Rest
+          <Tooltip text={"Monthly Cumulative Spending minus Rent & Utilities."} />
+        </span>
+        <span className="text-xl font-semibold">{formatCurrency(theRest)}</span>
+      </div>
+      <div className="bg-white rounded-lg shadow p-4 flex flex-col items-center">
+        <span className="text-xs text-gray-500 mb-1">
+          Tentative Monthly Budget
+          <Tooltip text={"Hardcoded to ₹50,000 for now."} />
+        </span>
+        <span className="text-xl font-semibold">{formatCurrency(tentativeMonthlyBudget)}</span>
+      </div>
+
+      {/* Second Row */}
+      <div className="bg-white rounded-lg shadow p-4 flex flex-col items-center">
+        <span className="text-xs text-gray-500 mb-1">
+          Avg Spend per Day
+          <Tooltip text={"(Fixed Costs / Days in Month) + (Cumulative Spending - Fixed Costs) / Days Elapsed This Month"} />
+        </span>
+        <span className="text-xl font-semibold">{formatCurrency(avgSpendPerDay)}</span>
+      </div>
+      <div className="bg-white rounded-lg shadow p-4 flex flex-col items-center">
+        <span className="text-xs text-gray-500 mb-1">
+          Target Spend per Day
+          <Tooltip text={"Monthly Budget / Days in Month"} />
+        </span>
+        <span className="text-xl font-semibold">{formatCurrency(targetSpendPerDay)}</span>
+      </div>
+      <div className="bg-white rounded-lg shadow p-4 flex flex-col items-center">
+        <span className="text-xs text-gray-500 mb-1">
+          Over / Under Target
+          <Tooltip text={"Avg Spend/Day - Target Spend/Day"} />
+        </span>
+        <span className={`text-xl font-semibold ${overUnderColor}`}>{overUnderLabel}</span>
+      </div>
+      <div className="bg-white rounded-lg shadow p-4 flex flex-col items-center">
+        <span className="text-xs text-gray-500 mb-1">
+          Spend/Day Allowed to Reach Target
+          <Tooltip text={"(Budget - Spending) / Days Left This Month (not including today)"} />
+        </span>
+        <span className="text-xl font-semibold">{formatCurrency(spendPerDayAllowed)}</span>
+      </div>
+    </div>
+  )
+}

--- a/components/StatsProgressMeters.tsx
+++ b/components/StatsProgressMeters.tsx
@@ -1,0 +1,62 @@
+import React from "react"
+
+interface StatsProgressMetersProps {
+  monthlyCumulativeSpending: number
+  tentativeMonthlyBudget: number
+  avgSpendPerDay: number
+  targetSpendPerDay: number
+}
+
+export const StatsProgressMeters: React.FC<StatsProgressMetersProps> = ({
+  monthlyCumulativeSpending,
+  tentativeMonthlyBudget,
+  avgSpendPerDay,
+  targetSpendPerDay,
+}) => {
+  // Helper for formatting INR
+  const formatCurrency = (amount: number) =>
+    amount.toLocaleString("en-IN", { style: "currency", currency: "INR", maximumFractionDigits: 2 })
+
+  const budgetPercent = Math.min((monthlyCumulativeSpending / tentativeMonthlyBudget) * 100, 100)
+  // Updated formula: avgSpendPerDay - targetSpendPerDay
+  const dailyPercent = avgSpendPerDay - targetSpendPerDay;
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+      {/* Monthly Budget Progress */}
+      <div className="bg-white rounded-lg shadow p-4">
+        <div className="flex justify-between mb-2">
+          <span className="text-xs text-gray-500">Monthly Budget Progress</span>
+          <span className="text-xs text-gray-500">{budgetPercent.toFixed(1)}%</span>
+        </div>
+        <div className="w-full bg-gray-200 rounded-full h-4">
+          <div
+            className={`h-4 rounded-full ${budgetPercent > 100 ? 'bg-red-500' : 'bg-blue-500'}`}
+            style={{ width: `${budgetPercent}%` }}
+          ></div>
+        </div>
+        <div className="flex justify-between mt-2 text-xs text-gray-500">
+          <span>{formatCurrency(monthlyCumulativeSpending)}</span>
+          <span>{formatCurrency(tentativeMonthlyBudget)}</span>
+        </div>
+      </div>
+      {/* Daily Spend Progress */}
+      <div className="bg-white rounded-lg shadow p-4">
+        <div className="flex justify-between mb-2">
+          <span className="text-xs text-gray-500">Avg Daily Spend vs Target</span>
+          <span className={`text-xs ${dailyPercent > 0 ? 'text-red-600' : 'text-green-600'}`}>{dailyPercent.toFixed(2)}</span>
+        </div>
+        <div className="w-full bg-gray-200 rounded-full h-4">
+          <div
+            className={`h-4 rounded-full ${dailyPercent > 100 ? 'bg-red-500' : 'bg-green-500'}`}
+            style={{ width: `${dailyPercent}%` }}
+          ></div>
+        </div>
+        <div className="flex justify-between mt-2 text-xs text-gray-500">
+          <span>{formatCurrency(avgSpendPerDay)}</span>
+          <span>{formatCurrency(targetSpendPerDay)}</span>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
- Updated StatsProgressMeters to show daily progress as avgSpendPerDay - targetSpendPerDay (raw difference)
- Refactored MonthlyStatsCards to display over/under target as a percentage: ((avgSpendPerDay - targetSpendPerDay) / targetSpendPerDay) * 100
- Simplified UI: now shows + or - percentage only, colored red if >1% over, green otherwise
- Updated tooltips and removed redundant wording for a cleaner, more intuitive dashboard